### PR TITLE
fix broken cross references with subdirectory exclusion

### DIFF
--- a/applications.rst
+++ b/applications.rst
@@ -44,4 +44,4 @@ HTTP, and so illustrates the “new” (post-HTTP) way to build
 applications. But before getting to these examples, we first describe
 the basic anatomy of an application.
 
-.. include:: anatomy.rst
+.. include:: applications/anatomy.rst

--- a/conf.py
+++ b/conf.py
@@ -89,7 +89,7 @@ language = 'en'
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = [u'_build', 'venv-docs', 'requirements.txt', 'Thumbs.db', 'private', '.DS_Store', '*/README.rst', 'software/*rst']
+exclude_patterns = [u'_build', 'venv-docs', 'requirements.txt', 'Thumbs.db', 'private', '.DS_Store', '*/README.rst', 'software/*rst', '*/*rst']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = None

--- a/index.rst
+++ b/index.rst
@@ -23,11 +23,11 @@ Larry Peterson and Bruce Davie
    :caption: Table of Contents
 
    preface.rst
-   introduction/introduction.rst
+   introduction.rst
    part_one.rst
    switches.rst
    part_two.rst
-   applications/applications.rst
+   applications.rst
    README.rst
    authors.rst
    latest.rst

--- a/introduction.rst
+++ b/introduction.rst
@@ -71,7 +71,7 @@ particular framing of the problem space. We call attention to such
 “exceptions to the rule” when they arise, and use them to illustrate
 that every system design requires judgement and makes tradeoffs.
 
-.. include:: requirements.rst
-.. include:: architecture.rst
-.. include:: protocols.rst
-.. include:: statmux.rst
+.. include:: introduction/requirements.rst
+.. include:: introduction/architecture.rst
+.. include:: introduction/protocols.rst
+.. include:: introduction/statmux.rst


### PR DESCRIPTION
Known issue with Sphinx where included files need to be excluded from top level processing