### PR TITLE
llp's pass over streams

### DIFF
--- a/part_three.rst
+++ b/part_three.rst
@@ -32,9 +32,13 @@ challenges, we incude descriptions of the following artifacts:
    DCTCP                       :ref:`Section 13.4.1 <artifact-dctcp>`
    DNS                         :ref:`Section 11.2 <artifact-dns>`
    gRPC                        :ref:`Section 15.2 <artifact-grpc>`
+   JPEG                        :ref:`Section 17.2 <artifact-jpeg>`
+   MPEG                        :ref:`Section 17.2 <artifact-mpeg>`
    QUIC                        :ref:`Section 15.3 <artifact-quic>`
    RDMA                        :ref:`Section 15.4 <artifact-rdma>`
    RoCE                        :ref:`Section 15.5 <artifact-roce>`
+   RTP                        :ref:`Section 17.3 <artifact-rtp>`
+   SIP                        :ref:`Section 17.4 <artifact-sip>`
    TCP                         :ref:`Chapter 12 <artifact-tcp>`
    TLS                         :ref:`Chapter 14 <artifact-tls>`
    ===========   ===========

--- a/stream.rst
+++ b/stream.rst
@@ -7,48 +7,39 @@
 Chapter |Stream|: Real-Time Streaming
 =====================================
 
-Audio and video have been streamed across the Internet for several decades. In
-the early days there were concerns that specialized queueing and
-resource reservations might be required to support these
-latency-sensitive applications, but dramatically increasing
-bandwidths of access links and the Internet's core has led to a state
-where video now makes up a majority of the bytes transmitted over the
-Internet. We touched on one technology that has enabled the rise of
-video in Chapter |Apps|: DASH (dynamic adaptive streaming over
-HTTP). However, DASH is only part of the story, since it works around
-the issue of latency with a startup delay and substantial buffering at
-the client. For use cases with tighter latency constraints, such as
-video conferencing and live events, we need a few other tools to
-manage the delivery of latency-sensitive media. This chapter examines
-the additional challenges in delivering real-time media and some of
-the technologies and protocols that have been developed to address
-them.
+Audio and video have been streamed across the Internet for several
+decades. In the early days there were concerns that specialized
+queuing and resource reservations might be required to support these
+latency-sensitive applications, but dramatically increasing bandwidths
+of access links and the Internet's core has led to a state where video
+now makes up a majority of the bytes transmitted over the Internet.
 
-Whether the media has real-time constraints or not, the first
-challenge is to encode it in a way that facilitates its transmission
-over packet networks. Video and audio coding have a rich history and
-it is only because of advances in this field that today's networks are
-able to carry high resolution video. So we begin our discussion with a
-brief overview of the techniques used to encode and compress audio and
-video streams prior to transmission.
+Streaming implies a rather broad class of applications, each with
+slightly different requirements. For example, early success stories
+had very loose latency requirements. If you wanted to watch a movie or
+listen to a song, it was acceptable to wait a few seconds before the
+stream started. This meant that video streaming services like Netflix
+and YouTube, as well as music streaming service like Pandora and
+Spotify, could use substantial buffering at the client to hide any
+delays in packet delivery. This led to the development of adaptive
+mechanisms, with the DASH protocol described in Chapter |Apps|
+being a prime example.
 
-Once we have encoded our media, we need to transport it over the
-network, and here we find that the reliable delivery model of TCP,
-which historically has been used by most Internet applications, isn't
-a good fit when we have tight latency constraints. The real-time
-transport protocol RTP is one alternative approach that has been
-widely adopted.
+But DASH doesn't work for every scenario. For use cases with tighter
+latency constraints, such as video conferencing and live events, we
+need additional tools to manage the delivery of latency-sensitive
+media. This is why we include the "real-time" qualifier, although even
+then, there is a spectrum of delay tolerances: a one-second pause
+after each speaker in a video conference call is much more disruptive
+than a seeing a live sporting event with a few seconds of delay.
 
-There is another problem faced by real-time applications, which is
-that the client-server model that is so common on the Web is a poor
-fit to many applications that are peer-to-peer, such as phone
-calls. This leads to the challenge known as session control.
-
-Finally, as with everything on the Internet, if an application is
-successful, we have to think about scaling issues. While DASH has been
-effective at leveraging CDNs, a different approach is emerging for
-real-time streaming. Our chapter concludes with a look at the emerging
-standards and implementations for scaling real-time streams.
+This chapter examines the additional challenges in delivering
+real-time media and some of the technologies and protocols that have
+been developed to address them.  Of particular note, the fact that we
+are delivering *media* (i.e., video and audio), and not some other
+type of data, plays a role in how we make sure delivery is timely. How
+we represent this data, and how much we compress it so it consumes
+fewer resources, is necessarily part of the story.
 
 .. include:: stream/design.rst
 .. include:: stream/coding.rst

--- a/stream.rst
+++ b/stream.rst
@@ -19,7 +19,7 @@ slightly different requirements. For example, early success stories
 had very loose latency requirements. If you wanted to watch a movie or
 listen to a song, it was acceptable to wait a few seconds before the
 stream started. This meant that video streaming services like Netflix
-and YouTube, as well as music streaming service like Pandora and
+and YouTube, as well as music streaming services like Pandora and
 Spotify, could use substantial buffering at the client to hide any
 delays in packet delivery. This led to the development of adaptive
 mechanisms, with the DASH protocol described in Chapter |Apps|
@@ -29,9 +29,10 @@ But DASH doesn't work for every scenario. For use cases with tighter
 latency constraints, such as video conferencing and live events, we
 need additional tools to manage the delivery of latency-sensitive
 media. This is why we include the "real-time" qualifier, although even
-then, there is a spectrum of delay tolerances: a one-second pause
-after each speaker in a video conference call is much more disruptive
-than a seeing a live sporting event with a few seconds of delay.
+then, there is a spectrum of delay tolerances: a one-second delay when
+trying to reply to a speaker in a video conference call is much more
+disruptive than a few seconds of delay when watching a live sporting
+event.
 
 This chapter examines the additional challenges in delivering
 real-time media and some of the technologies and protocols that have

--- a/stream/coding.rst
+++ b/stream/coding.rst
@@ -43,10 +43,10 @@ bits of color information, so each frame is
 
 If you want to send 24 frames per second, that would be over
 1 Gbps.  That’s more than most Internet users have access to even
-today, and by orders
+today, and more by orders
 of magnitude for most of the history of the Internet.  By
 contrast, modern compression techniques can get a reasonably
-high-quality HDTV signal down to the range of 10 Mbps, a two order of
+high-quality HDTV signal down to the range of 10 Mbps, a two orders of
 magnitude reduction and well within the reach of most broadband users.
 Similar compression gains apply to lower quality video such as YouTube
 clips—Web video could never have reached its current popularity

--- a/stream/coding.rst
+++ b/stream/coding.rst
@@ -1,3 +1,6 @@
+.. _artifact-mpeg:
+.. _artifact-jpeg:
+
 |Stream|.2 Coding and Compression
 ----------------------------------
 
@@ -38,7 +41,7 @@ bits of color information, so each frame is
 
 .. centered:: 1080 × 1920 × 24 = 50 *Mb*
 
-so if you want to send 24 frames per second, that would be over
+If you want to send 24 frames per second, that would be over
 1 Gbps.  That’s more than most Internet users have access to even
 today, and by orders
 of magnitude for most of the history of the Internet.  By
@@ -50,159 +53,44 @@ clips—Web video could never have reached its current popularity
 without compression to make all those videos fit within
 the bandwidth of contemporary networks.
 
-Compression techniques as applied to multimedia have been an area of
-great innovation, particularly lossy compression.  Lossless techniques
-also have an important role to play, however.  Indeed, most of the
-lossy techniques include some steps that are lossless, so we begin our
-discussion with an overview of lossless compression.
+This section works through the problem in three steps: (1) how media
+is represented in the first place (independent of compression); (2)
+how still images are compressed, and (3) how video, which is
+conceptually a sequence of still images, is compressed. We use the
+familiar JPEG and MPEG standards to illustrate the ideas.
 
-|Stream|.2.1 Lossless Compression Techniques
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+|Stream|.2.1 Image Representation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In many ways, compression is inseparable from data encoding. When
-thinking about how to encode a piece of data in a set of bits, we might
-just as well think about how to encode the data in the smallest set of
-bits possible. For example, if you have a block of data that is made up
-of the 26 symbols A through Z, and if all of these symbols have an equal
-chance of occurring in the data block you are encoding, then encoding
-each symbol in 5 bits is the best you can do (since 2\ :sup:`5` = 32
-is the lowest power of 2 above 26). If, however, the symbol R occurs
-50% of the time, then it would be a good idea to use fewer bits to
-encode the R than any of the other symbols. In general, if you know the
-relative probability that each symbol will occur in the data, then you
-can assign a different number of bits to each possible symbol in a way
-that minimizes the number of bits it takes to encode a given block of
-data. This is the essential idea of *Huffman codes*, one of the
-important early developments in data compression.
+Given the ubiquitous use of digital imagery—this use was spawned by
+the invention of graphical displays, not high-speed networks—the need
+for standard representation formats and compression algorithms for
+digital imagery data has become essential. In response to this need,
+the ISO defined a digital image format known as *JPEG*, named after
+the Joint Photographic Experts Group that designed it. (The “Joint” in
+JPEG stands for a joint ISO/ITU effort.) JPEG is the most widely used
+format for still images in use today. At the heart of the definition
+of the format is a compression algorithm, which we describe in the
+next subsection.  But we start with the simpler question of exactly
+what makes up a digital image.
 
-Run Length Encoding
-++++++++++++++++++++++++++++++
-
-Run length encoding (RLE) is a compression technique with a brute-force
-simplicity. The idea is to replace consecutive occurrences of a given
-symbol with only one copy of the symbol, plus a count of how many times
-that symbol occurs—hence, the name *run length*. For example, the string
-``AAABBCDDDD`` would be encoded as ``3A2B1C4D``.
-
-RLE turns out to be useful for compressing some classes of images. It
-can be used in this context by comparing adjacent pixel values and then
-encoding only the changes. For images that have large homogeneous
-regions, this technique is quite effective. For example, it is not
-uncommon that RLE can achieve compression ratios on the order of 8-to-1
-for scanned text images. RLE works well on such files because they often
-contain a large amount of white space that can be removed. For those old
-enough to remember the technology, RLE was the key compression algorithm
-used to transmit faxes. However, for images with even a small degree of
-local variation, it is not uncommon for compression to actually increase
-the image byte size, since it takes 2 bytes to represent a single symbol
-when that symbol is not repeated.
-
-Differential Pulse Code Modulation
-++++++++++++++++++++++++++++++++++++++++
-
-Another simple lossless compression algorithm is Differential Pulse Code
-Modulation (DPCM). The idea here is to first output a reference symbol
-and then, for each symbol in the data, to output the difference between
-that symbol and the reference symbol. For example, using symbol A as the
-reference symbol, the string ``AAABBCDDDD`` would be encoded as
-``A0001123333`` because A is the same as the reference symbol, B has a
-difference of 1 from the reference symbol, and so on. Note that this
-simple example does not illustrate the real benefit of DPCM, which is
-that when the differences are small they can be encoded with fewer bits
-than the symbol itself. In this example, the range of differences, 0-3,
-can be represented with 2 bits each, rather than the 7 or 8 bits
-required by the full character. As soon as the difference becomes too
-large, a new reference symbol is selected.
-
-DPCM works better than RLE for most digital imagery, since it takes
-advantage of the fact that adjacent pixels are usually similar. Due to
-this correlation, the dynamic range of the differences between the
-adjacent pixel values can be significantly less than the dynamic range
-of the original image, and this range can therefore be represented using
-fewer bits. Using DPCM, we have measured compression ratios of 1.5-to-1
-on digital images. DPCM also works on audio, because adjacent samples of
-an audio waveform are likely to be close in value.
-
-A slightly different approach, called *delta encoding*, simply encodes a
-symbol as the difference from the previous one. Thus, for example,
-``AAABBCDDDD`` would be represented as ``A001011000``. Note that delta
-encoding is likely to work well for encoding images where adjacent
-pixels are similar. It is also possible to perform RLE after delta
-encoding, since we might find long strings of 0s if there are many
-similar symbols next to each other.
-
-Dictionary-Based Methods
-++++++++++++++++++++++++
-
-The final lossless compression method we consider is the
-dictionary-based approach, of which the Lempel-Ziv (LZ) compression
-algorithm is the best known. The Unix ``compress`` and ``gzip``
-commands use variants of the LZ algorithm.
-
-The idea of a dictionary-based compression algorithm is to build a
-dictionary (table) of variable-length strings (think of them as common
-phrases) that you expect to find in the data and then to replace each of
-these strings when it appears in the data with the corresponding index
-to the dictionary. For example, instead of working with individual
-characters in text data, you could treat each word as a string and
-output the index in the dictionary for that word. To further elaborate
-on this example, the word *compression* has the index 4978 in one
-particular dictionary; it is the 4978th word in
-``/usr/share/dict/words``. To compress a body of
-text, each time the string “compression” appears, it would be replaced
-by 4978. Since this particular dictionary has just over 25,000 words in
-it, it would take 15 bits to encode the index, meaning that the string
-“compression” could be represented in 15 bits rather than the 77 bits
-required by 7-bit ASCII. This is a compression ratio of 5-to-1! As an
-example, we ran the first chapter of this book through ``gzip`` and it
-shrank from 78kB to 27kB, about 35% of its original size.
-
-Of course, this leaves the question of where the dictionary comes from.
-One option is to define a static dictionary, preferably one that is
-tailored for the data being compressed. A more general solution, and the
-one used by LZ compression, is to adaptively define the dictionary based
-on the contents of the data being compressed. In this case, however, the
-dictionary constructed during compression has to be sent along with the
-data so that the decompression half of the algorithm can do its job.
-Exactly how you build an adaptive dictionary has been a subject of
-extensive research.
-
-|Stream|.2.2 Image Representation and Compression (GIF, JPEG)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Given the ubiquitous use of digital imagery—this use was spawned by the
-invention of graphical displays, not high-speed networks—the need for
-standard representation formats and compression algorithms for digital
-imagery data has become essential. In response to this need, the ISO
-defined a digital image format known as *JPEG*, named after the Joint
-Photographic Experts Group that designed it. (The “Joint” in JPEG stands
-for a joint ISO/ITU effort.) JPEG is the most widely used format for
-still images in use today. At the heart of the definition of the format
-is a compression algorithm, which we describe below. Many techniques
-used in JPEG also appear in MPEG, the set of standards for video
-compression and transmission created by the Moving Picture Experts
-Group.
-
-Before delving into the details of JPEG, we observe that there are quite
-a few steps to get from a digital image to a compressed representation
-of that image that can be transmitted, decompressed, and displayed
-correctly by a receiver. You probably know that digital images are made
-up of pixels (hence, the megapixels quoted in smartphone camera
+For starters, it's probably obvious that digital images are made up of
+pixels (hence, the megapixels quoted in smartphone camera
 advertisements). Each pixel represents one location in the
-two-dimensional grid that makes up the image, and for color images each
-pixel has some numerical value representing a color. There are lots of
-ways to represent colors, referred to as *color spaces*; the one most
-people are familiar with is RGB (red, green, blue). You can think of
-color as being a three dimensional quantity—you can make any color out
-of red, green, and blue light in different amounts. In a
+two-dimensional grid that makes up the image, and for color images
+each pixel has some numerical value representing a color. There are
+lots of ways to represent colors, referred to as *color spaces*; the
+one most people are familiar with is RGB (red, green, blue). You can
+think of color as being a three dimensional quantity—you can make any
+color out of red, green, and blue light in different amounts. In a
 three-dimensional space, there are lots of different, valid ways to
 describe a given point (consider Cartesian and polar coordinates, for
 example). Similarly, there are various ways to describe a color using
 three quantities, and the most common alternative to RGB is YUV. The Y
 is luminance, roughly the overall brightness of the pixel, and U and V
 contain chrominance, or color information. Confoundingly, there are a
-few different variants of the YUV color space as well. More on this in a
-moment.
+few different variants of the YUV color space as well. More on this in
+a moment.
 
 The significance of this discussion is that the encoding and
 transmission of color images (either still or moving) requires agreement
@@ -212,43 +100,16 @@ captured by the sender. Hence, agreeing on a color space definition (and
 perhaps a way to communicate which particular space is in use) is part
 of the definition of any image or video format.
 
-Let’s look at the example of the Graphical Interchange Format (GIF). GIF
-uses the RGB color space and starts out with 8 bits to represent each of
-the three dimensions of color for a total of 24 bits. Rather than
-sending those 24 bits per pixel, however, GIF first reduces 24-bit color
-images to 8-bit color images. This is done by identifying the colors
-used in the picture, of which there will typically be considerably fewer
-than 2\ :sup:`24`, and then picking the 256 colors that most closely
-approximate the colors used in the picture. There might be more than 256
-colors, however, so the trick is to try not to distort the color too much
-by picking 256 colors such that no pixel has its color changed too much.
-
-The 256 colors are stored in a table, which can be indexed with an 8-bit
-number, and the value for each pixel is replaced by the appropriate
-index. Note that this is an example of lossy compression for any picture
-with more than 256 colors. GIF then runs an LZ variant over the result,
-treating common sequences of pixels as the strings that make up the
-dictionary—a lossless operation. Using this approach, GIF is sometimes
-able to achieve compression ratios on the order of 10:1, but only when
-the image consists of a relatively small number of discrete colors.
-Graphical logos, for example, are handled well by GIF. Images of natural
-scenes, which often include a more continuous spectrum of colors, cannot
-be compressed at this ratio using GIF. It is also not too hard for a
-human eye to detect the distortion caused by the lossy color reduction
-of GIF in some cases.
-
-The JPEG format is considerably more well suited to photographic images,
-as you would hope given the name of the group that created it. JPEG does
-not reduce the number of colors like GIF. Instead, JPEG starts off by
+The JPEG format is tailored for photographic images. It starts by
 transforming the RGB colors (which are what you usually get out of a
-digital camera) to the YUV space. The reason for this has to do with the
-way the eye perceives images. There are receptors in the eye for
-brightness, and separate receptors for color. Because we’re very good at
-perceiving variations in brightness, it makes sense to spend more bits
-on transmitting brightness information. Since the Y component of YUV is,
-roughly, the brightness of the pixel, we can compress that component
-separately, and less aggressively, from the other two (chrominance)
-components.
+digital camera) to the YUV space. The reason for this has to do with
+the way the eye perceives images. There are receptors in the eye for
+brightness, and separate receptors for color. Because we’re very good
+at perceiving variations in brightness, it makes sense to spend more
+bits on transmitting brightness information. Since the Y component of
+YUV is, roughly, the brightness of the pixel, we can compress that
+component separately, and less aggressively, from the other two
+(chrominance) components.
 
 As noted above, YUV and RGB are alternative ways to describe a point in
 a 3-dimensional space, and it’s possible to convert from one color space
@@ -281,30 +142,33 @@ in this case would be zero. That is, a fully white pixel is
 
    Subsampling the U and V components of an image.
 
-Once the image has been transformed into YUV space, we can now think
-about compressing each of the three components separately. We want to
-be more aggressive in compressing the U and V components, to which
-human eyes are less sensitive. One way to compress the U and V
-components is to *subsample* them. The basic idea of subsampling is to
-take a number of adjacent pixels, calculate the average U or V value
-for that group of pixels, and transmit that, rather than sending the
-value for every pixel. :numref:`Figure %s <fig-yuvsub>` illustrates
-the point. The luminance (Y) component is not subsampled, so the Y
-value of all the pixels will be transmitted, as indicated by the 16 ×
-16 grid of pixels on the left. In the case of U and V, we treat each
-group of four adjacent pixels as a group, calculate the average of the
-U or V value for that group, and transmit that. Hence, we end up with
-an 8 × 8 grid of U and V values to transmit. Thus, in this example,
-for every four pixels, we transmit six values (four Y and one each of
-U and V) rather than the original 12 values (four each for all three
-components), for a 50% reduction in information.
+|Stream|.2.2 Image Compression
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Once the image has been transformed into YUV space, we are ready to
+compress each of the three components separately. We want to be more
+aggressive in compressing the U and V components, to which human eyes
+are less sensitive. One way to compress the U and V components is to
+*subsample* them. The basic idea of subsampling is to take a number of
+adjacent pixels, calculate the average U or V value for that group of
+pixels, and transmit that, rather than sending the value for every
+pixel. :numref:`Figure %s <fig-yuvsub>` illustrates the point. The
+luminance (Y) component is not subsampled, so the Y value of all the
+pixels will be transmitted, as indicated by the 16 × 16 grid of pixels
+on the left. In the case of U and V, we treat each group of four
+adjacent pixels as a group, calculate the average of the U or V value
+for that group, and transmit that. Hence, we end up with an 8 × 8 grid
+of U and V values to transmit. Thus, in this example, for every four
+pixels, we transmit six values (four Y and one each of U and V) rather
+than the original 12 values (four each for all three components), for
+a 50% reduction in information.
 
 It’s worth noting that you could be either more or less aggressive in
 the subsampling, with corresponding increases in compression and
 decreases in quality. The subsampling approach shown here, in which
 chrominance is subsampled by a factor of two in both horizontal and
 vertical directions (and which goes by the identification 4:2:0),
-happens to match the most common approach used for both JPEG and MPEG.
+happens to match the most commonly used approach.
 
 .. _fig-jpeg:
 .. figure:: stream/figures/f07-12-9780123850591.png
@@ -479,12 +343,12 @@ The final phase of JPEG encodes the quantized frequency coefficients
 in a compact form. This results in additional compression, but this
 compression is lossless. Starting with the DC coefficient in position
 (0,0), the coefficients are processed in the zigzag sequence shown in
-:numref:`Figure %s <fig-zigzag>`. Along this zigzag, a form of run
-length encoding is used—RLE is applied to only the 0 coefficients,
-which is significant because many of the later coefficients are 0. The
-individual coefficient values are then encoded using a Huffman
-code. (The JPEG standard allows the implementer to use an arithmetic
-coding instead of the Huffman code.)
+:numref:`Figure %s <fig-zigzag>`. Along this zigzag, a form of Run
+Length Encoding (RLE) is used—RLE is applied to only the 0
+coefficients, which is significant because many of the later
+coefficients are 0. The individual coefficient values are then encoded
+using a Huffman code. (RLE and Huffman codes are two examples of
+*lossless* compression algorithms; see the sidebar for a summary.)
 
 .. _fig-zigzag:
 .. figure:: stream/figures/f07-13-9780123850591.png
@@ -493,11 +357,42 @@ coding instead of the Huffman code.)
 
    Zigzag traversal of quantized frequency coefficients.
 
+.. sidebar:: Other Compression Algorithms
+
+   *When thinking about how to encode a piece of data in a set of
+   bits, we might just as well think about how to encode the data in
+   the smallest set of bits possible. For example, if a block of data
+   is made up of the 26 symbols A through Z, and if all of these
+   symbols have an equal chance of occurring in the data block you are
+   encoding, then encoding each symbol in 5 bits is the best you can
+   do (since 25 = 32 is the lowest power of 2 above 26). If, however,
+   the symbol R occurs 50% of the time, then it would be a good idea
+   to use fewer bits to encode the R than any of the other symbols. In
+   general, if you know the relative probability that each symbol will
+   occur in the data, then you can assign a different number of bits
+   to each possible symbol in a way that minimizes the number of bits
+   it takes to encode a given block of data. This is the essential
+   idea of Huffman codes, one of the important early developments in
+   data compression.*
+
+   *Run length encoding (RLE) is a another compression technique.  The
+   idea is to replace consecutive occurrences of a given symbol with
+   only one copy of the symbol, plus a count of how many times that
+   symbol occurs—hence, the name run length. For example, the string
+   AAABBCDDDD would be encoded as 3A2B1C4D.*
+
+   *Another straightforward idea is the dictionary-based approach, of
+   which the Lempel-Ziv (LZ) compression algorithm is the best
+   known. The idea is to build a dictionary (table) of variable-length
+   strings (think of them as common phrases) that you expect to find
+   in the data and then to replace each of these strings when it
+   appears in the data with the corresponding index to the dictionary.*
+
 In addition, because the DC coefficient contains a large percentage of
 the information about the 8 × 8 block from the source image, and images
 typically change slowly from block to block, each DC coefficient is
 encoded as the difference from the previous DC coefficient. This is the
-delta encoding approach described in a later section.
+delta encoding approach described in the next section.
 
 JPEG includes a number of variations that control how much compression
 you achieve versus the fidelity of the image. This can be done, for
@@ -508,7 +403,7 @@ achieved with JPEG. Ratios of 30:1 are common, and higher ratios are
 certainly possible, but *artifacts* (noticeable distortion due to
 compression) become more severe at higher ratios.
 
-|Stream|.2.3 Video Compression (MPEG)
+|Stream|.2.3 Video Compression
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 We now turn our attention to the MPEG format, named after the Moving
@@ -696,20 +591,23 @@ algorithm every possible degree of freedom in how it encodes a given
 video stream, resulting in different video transmission rates. It also
 comes from the evolution of the standard over time, with the Moving
 Picture Experts Group working hard to retain backwards compatibility
-(e.g., MPEG-1, MPEG-2, MPEG-4). What we describe in this book is the
-essential ideas underlying MPEG-based compression, but certainly not all
-the intricacies involved in an international standard.
+(e.g., MPEG-1, MPEG-2, MPEG-4, MPEG-H). What we describe in this book
+is the essential ideas underlying MPEG-based compression, but
+certainly not all the intricacies involved in an international standard.
 
-What’s more, MPEG is not the only standard available for encoding video.
-For example, the ITU-T has also defined the *H series* for encoding
-real-time multimedia data. Generally, the H series includes standards
-for video, audio, control, and multiplexing (e.g., mixing audio, video,
-and data onto a single bit stream). Within the series, H.261 and H.263
-were the first- and second-generation video encoding standards. In
-principle, both H.261 and H.263 look a lot like MPEG: They use DCT,
-quantization, and interframe compression. The differences between
-H.261/H.263 and MPEG are in the details.
+What’s more, MPEG is not the only standard available for encoding
+video.  For example, the ITU-T has also defined the *H series* for
+encoding real-time multimedia data. Generally, the H series includes
+standards for video, audio, control, and multiplexing (e.g., mixing
+audio, video, and data onto a single bit stream). Within the series,
+H.261 and H.263 were the first- and second-generation video encoding
+standards. In principle, both H.261 and H.263 look a lot like MPEG:
+They use DCT, quantization, and interframe compression. The
+differences between H.261/H.263 and MPEG are in the details.
 
-Today, a partnership between the ITU-T and the MPEG group has lead to
-the joint H.264/MPEG-4 standard, which is used for both Blu-ray Discs
-and by many popular streaming sources (e.g., YouTube, Vimeo).
+A partnership between the ITU-T and the MPEG group lead to the joint
+H.264/MPEG-4 standard, which is used for both Blu-ray Discs and by
+many popular streaming sources, such as YouTube. The recent upgrade of
+graphical displays to 4k comes with yet another round of
+standardization, published as H.265/MPEG-H.
+

--- a/stream/design.rst
+++ b/stream/design.rst
@@ -52,7 +52,7 @@ another so that audio and video tracks can be synchronized. It could
 be done by the application, but it is a common enough problem that
 it's helpful to have a transport protocol that takes care of this
 task. Identifying those useful common tasks and building them into a
-real-time transport led to the development of RTP (Real-Time
+real-time transport led to the development of RTP (Real-time Transport
 Protocol).
 
 Third, since many real-time applications involve two or more humans

--- a/stream/design.rst
+++ b/stream/design.rst
@@ -1,29 +1,31 @@
 |Stream|.1 Design Issues
 -----------------------------------------------
+
 The idea of sending real-time media over packet networks goes back at
-least to the 1980s, when researchers at Bellcore built an
-``Etherphone'' that transmitted a 64kbps audio stream, captured using
-something that looked exactly like a 1980s telephone handset, over an
-Ethernet. Since the backbone of the Internet in those days was only
-56kbps, it would be a few more years before this technology found its
-way to the Internet. And only in the late 1990s did the bandwidths
-available across the Internet start to make "voice over IP" feasible.
+least to the 1980s, when researchers at Bellcore built an "Etherphone"
+that transmitted a 64kbps audio stream—captured using something that
+looked exactly like a 1980s telephone handset—over an Ethernet. Since
+the backbone of the Internet in those days was only 56kbps, it would
+be a few more years before this technology found its way to the
+Internet. And only in the late 1990s did the bandwidths available
+across the Internet start to make "voice over IP" feasible.
 
 Today, of course, audio and video make up a large fraction of the
 Internet's traffic. But there is more to the story than just Internet
 link bandwidths catching up with the demands of multimedia
-applications.
+applications. We highlight four major issues.
 
-First of all, the coding and compression of audio and video content
-presents an interesting study in how humans process information. There
-is a *lot* of information in high-resolution video, for example, but a
-much of it is either redundant or of limited value when perceived by a
+First, the coding and compression of audio and video content presents
+an interesting study in how humans process information. There is a
+*lot* of information in high-resolution video, for example, but a much
+of it is either redundant or of limited value when perceived by a
 human eye. An example of redundant content is the unchanging
 background of a video. If we can send the background once and then say
 "don't make any changes to the background" that requires a lot less
-bandwidth than sending the same background image at 30 frames per second. The
-hard part is algorithmically determining which part of the image isn't
-changing, and that is one thing that modern video coding does.
+bandwidth than sending the same background image at 30 frames per
+second. The hard part is to algorithmically determine which part of the
+image isn't changing, and that is one thing that modern video coding
+does.
 
 Similarly, images contain both high and low spatial frequency
 information, and the human eye is more sensitive to the lower
@@ -32,51 +34,53 @@ transmitting the information that has more value to the human eye.
 
 Compression of video and audio, therefore, depends on an understanding
 of human perception, and there have been decades of research on how to
-optimize compression while maintaining high perceived quality. Compression
-also has to take account of the fact that networks will occasionally
-lose data; this means that you can't afford to completely remove
-redundant information, or one lost packet might render the entirety of
-a video useless to the recipient. 
+optimize compression while maintaining high perceived
+quality. Compression also has to take account of the fact that
+networks will occasionally lose data; this means that you can't afford
+to completely remove redundant information, or one lost packet might
+render the entirety of a video useless to the recipient.
 
-When transporting real-time media across networks, it soon becomes
-apparent that the reliable byte-stream model of TCP isn't suitable
-because of the potentially unbounded delay of waiting for the
-retransmission of lost packets. A single packet loss is often
-preferable to a long delay. While this might lead one to assume that
-UDP would be a better choice, that leaves a lot of work up to the
-application. A simple example is conveying timing information from one
-participant to another so that audio and video tracks can be
-synchronized. It could be done by the application, but it is a common
-enough problem that it's helpful to have a transport protocol that
-takes care of this task. Identifying those useful common tasks and
-building them into a real-time transport led to the development of RTP.
+The second issue concerns the transport protocol. When sending
+real-time media across networks, it soon becomes apparent that the
+reliable byte-stream model of TCP isn't suitable because of the
+potentially unbounded delay of waiting for the retransmission of lost
+packets. A single packet loss is often preferable to a long
+delay. While this might lead one to assume that UDP would be a better
+choice, that leaves a lot of work up to the application. A simple
+example is conveying timing information from one participant to
+another so that audio and video tracks can be synchronized. It could
+be done by the application, but it is a common enough problem that
+it's helpful to have a transport protocol that takes care of this
+task. Identifying those useful common tasks and building them into a
+real-time transport led to the development of RTP (Real-Time
+Protocol).
 
-Since many real-time applications involve two or more humans conversing with
-each other, many such applications are a poor fit to the client server
-model of communication, in which the client makes a request to a
-well-known server. The problem of how to bring participants together
-in a *session* and how to communicate all the information (such as the chosen
-coding standards) among participants is known as *session
-control*. Solving these issues has give rise to a set of protocols
-designed specifically for applications connecting sets of participants
-rather than clients making requests of servers.
+Third, since many real-time applications involve two or more humans
+conversing with each other, many such applications are a poor fit to
+the client-server model of communication, in which the client makes a
+request to a well-known server. The problem of how to bring
+participants together in a *session* and how to communicate all the
+information (such as the chosen coding standards) among participants
+is known as *session control*. Solving these issues has give rise to a
+set of protocols designed specifically for applications connecting
+sets of participants rather than clients making requests of servers.
 
-With real-time applications now commonplace on the Internet, you might
-think that there are no further problems to solve. However, it turns
-out that large-scale, real-time communications face something of a
-scaling issue. While most of us have been on large video conferences
-that seem to work well, the solution normally depends on some
-high-capactiy cloud service to send the video out to the
-participants. The problem of how to distribute real-time media to
-large audiences in a scalable manner is gaining renewed attention and
-we conclude the chapter by looking at an approach which aims to be as
+The fourth issue is a familiar one: how to scale the system. While
+most of us have been on large video conferences that seem to work
+well, the solution normally depends on some high-capacity cloud
+service to send the video out to the participants. The problem of how
+to distribute real-time media to large audiences—imagine a world-wide
+audience watching the World Cup—is gaining renewed attention and we
+conclude the chapter by looking at an approach which aims to be as
 scalable as today's delivery of entertainment video using DASH.
 
-One final design question was how to ensure that latency-sensitive
-traffic for applications like VOIP and video conferences could make it
-across the network without encountering excessive queueing delays. We
-discussed in Chapter |Capacity| a number of approaches to queueing
-that have been developed so that some traffic can receiver lower delay
-even when the overall load is high. However, for much of today's
-Internet, those mechanisms are not deployed; the solution has simply
-been to deploy enough capacity that delay is mostly acceptably low.
+We conclude by drawing attention to what has turned out to be a
+non-issue.  For many years it seemed obvious that supporting
+latency-sensitive traffic for applications like VOIP and video
+conferences would require in-network mechanisms to avoid excessive
+queuing delays. Chapter |Capacity| described a number of approaches to
+queuing that have been developed so that some traffic can receiver
+lower delay even when the overall load is high. However, for much of
+today's Internet, those mechanisms are not deployed; the solution has
+simply been to deploy enough capacity that delay is mostly acceptably
+low. So far, this approach has worked.

--- a/stream/scale.rst
+++ b/stream/scale.rst
@@ -1,8 +1,8 @@
 
 |Stream|.5 Scaling Real-time Applications
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------------------
 
-Back in Chapter |Apps| we observed that the success of DASH to deliver
+In Chapter |Apps| we observed that the success of DASH to deliver
 steaming media at scale had a lot to do with its effective use of HTTP
 as the delivery mechanism. The web has developed over the decades to
 make HTTP delivery very efficient, particularly through the use of
@@ -20,8 +20,8 @@ interactive session.
 
 The traditional approach to real-time applications is to run them over
 UDP rather than TCP and deal with packet losses in the application
-rather than by retransmission. This is how RTP, described in Section
-|Stream|.2, typically operates. However, this doesn't tackle the
+rather than by retransmission. As we say in Section |Stream|.3, this
+is how RTP typically operates. However, this doesn't tackle the
 question of scale. How can a video stream be distributed out to
 hundreds of thousands of viewers, as might be required for a live
 sporting event, for example?
@@ -31,25 +31,26 @@ For a lot of video conference solutions, the answer has been to use a
 video and audio to the mixer, and a mixed video and audio stream is
 sent back out to every recipient. That works reasonably well up to a
 point, but it does mean that the same media stream is being sent out
-many times from the cloud. For large scale events, a more efficient
-replication method would be ideal.
+many times from the cloud. Any single cloud site has significant
+capacity, but for truly large scale events, a more efficient
+replication method is required.
 
-For a while, the standard answer to this problem was multicast at the
-IP layer. Replication of packets was handled directly by the routers,
-with receivers joining a multicast group to receive the content, and
-senders directing their traffic to a multicast IP address. This
-technology is probably still running in some enterprise networks today
-but largely failed to launch in the broader Internet. The core idea,
-however, of efficient replication at intermediate nodes, lives on in
-overlay networks such as CDNs. And there is an ongoing effort to
-standardize a type of overlay specifically for real-time streams. That
-effort is known as "Media Over QUIC" (MEOW) but the name doesn't really
-tell you much about all the moving parts. Let's take a look at the
-main features of MoQ.
+For several years, the standard answer to this problem was multicast
+at the IP layer. Replication of packets was handled directly by the
+routers, with receivers joining a multicast group to receive the
+content, and senders directing their traffic to a multicast IP
+address. This technology is probably still running in some enterprise
+networks today, but multicast IP largely failed to launch in the
+broader Internet. The core idea, however, of efficient replication at
+intermediate nodes, lives on in overlay networks such as CDNs. And
+there is an now an effort to standardize an analogous type of overlay
+specifically for real-time streams. That effort is known as "Media
+Over QUIC" (MoQ) but the name doesn't really tell you much about all
+the moving parts. Let's take a look at the main features of MoQ.
 
 There is a well-established concept in distributed systems known as
 the *publish/subscribe* pattern. Publish/subscribe is a generic
-approach to data distribution: data is published to some sort of
+approach to data distribution: data is published onto an abstract
 channel, and subscribers to the channel receive the data. Notably, the
 publishers and subscribers don't need to know about each other; they
 only need to know about the channel. This turns out to be a good fit
@@ -64,31 +65,29 @@ receive it.
 Tracks are made up of *groups*, which in turn are made up of
 *objects*. A group is independently decodable, that is, a receiver of
 a group can decode it without having received any prior groups from
-the track. A group would likely correspond to a group of
-pictures (GOP) in a video stream, which includes an I frame and some
-number of B and P frames as described in Section |Stream|.1. The fact
-that the group can be decoded independently means a subscriber can
-join a channel and immediately decode the
-media once a group is received.
+the track. A group would likely correspond to a group of pictures
+(GOP) in a video stream, which includes an I frame and some number of
+B and P frames as described in Section |Stream|.2. The fact that the
+group can be decoded independently means a subscriber can join a
+channel and immediately decode the media once a group is received.
 Objects are the individual units of data transmitted by MoQ.
 
-As you probably guessed from the name, MoQ uses QUIC as the underlying
-transport. This might seem at odds with the desire to minimize
-latency, since QUIC, as we discussed in Section |Message|.3, uses
-retransmission of lost packets to ensure reliable delivery. MoQ takes
-advantage of some of the features of QUIC to get around this. In
-particular, recall that the lightweight streams of QUIC allow for
-independent components of a QUIC connection to proceed without being
-blocked by each other. So MoQ uses streams to ensure that different
-parts of a media stream can be sent independently of each other. One
-use of this is to discard the higher resolution parts of a video if
-necessary to deal with congestion. It is also possible to just
-terminate a stream if, for example, the observed level of congestion
-suggests that sending this part of the media would only exacerbate
-congestion, or the information in the stream would arrive too late to
-be useful.  MoQ objects have an associated *priority* that can be used
-to make decisions about which streams to transmit and which to
-terminate.
+As its name implies, MoQ uses QUIC as the underlying transport. This
+might seem at odds with the desire to minimize latency, since QUIC, as
+we discussed in Section |Message|.3, uses retransmission of lost
+packets to ensure reliable delivery. MoQ takes advantage of some of
+the features of QUIC to get around this. In particular, recall that
+the lightweight streams of QUIC allow for independent components of a
+QUIC connection to proceed without being blocked by each other. So MoQ
+uses streams to ensure that different parts of a media stream can be
+sent independently of each other. One use of this is to discard the
+higher resolution parts of a video if necessary to deal with
+congestion. It is also possible to just terminate a stream if, for
+example, the observed level of congestion suggests that sending this
+part of the media would only exacerbate congestion, or the information
+in the stream would arrive too late to be useful.  MoQ objects have an
+associated *priority* that can be used to make decisions about which
+streams to transmit and which to terminate.
 
 The key to scalability in MoQ is the use of *relays*, a form of
 overlay that handles replication of media. Just as we saw in Chapter
@@ -103,7 +102,7 @@ to know about publishers and *vice versa*.
    :width: 500px
    :align: center
 
-   Relays form an overlay for media distribution
+   Relays form an overlay for media distribution.
 
 Relays form an overlay of nodes that can store, forward, and replicate
 objects, as shown in :numref:`Figure %s <fig-relays>`. They don't need
@@ -135,7 +134,7 @@ since the specifications are still evolving and implementations are
 trying to track the specifications. Nevertheless, this approach draws
 on the success of existing technologies such as QUIC and DASH and has
 the weight of major industry players behind it, so there is reason to
-be optimistic for its future. The implemention of the relay function
+be optimistic for its future. The implementation of the relay function
 in a large-scale deployment at Cloudflare is one example of the
 industry investment in MoQ; you can read more about MoQ and its
 implementation in their blog on the subject.

--- a/stream/scale.rst
+++ b/stream/scale.rst
@@ -89,6 +89,14 @@ in the stream would arrive too late to be useful.  MoQ objects have an
 associated *priority* that can be used to make decisions about which
 streams to transmit and which to terminate.
 
+The lightweight streams of QUIC allow QUIC to function at
+an intermediate point in the design space between TCP and
+UDP. Reliable delivery can be applied selectively to individual
+streams, and congestion control can limit the total amount of traffic
+in a QUIC connection when required, but lower priority streams can be
+sacrificed to ensure that latency remains withing bounds and more important
+packets are not stuck waiting for less important ones to arrive.
+
 The key to scalability in MoQ is the use of *relays*, a form of
 overlay that handles replication of media. Just as we saw in Chapter
 |Overlay| how CDNs can scale the delivery of HTTP traffic, MoQ relays

--- a/stream/session.rst
+++ b/stream/session.rst
@@ -1,3 +1,5 @@
+.. _artifact-sip:
+
 |Stream|.4 Session Control
 --------------------------
 
@@ -9,8 +11,9 @@ conferencing, don't conform so well to that model. There is no
 well-defined server for a client to connect to. Instead, we want to
 establish a communication *session* among the participants. These
 sorts of applications typically use something called *session
-control*. We begin our discussion with the widely used SIP, the
-session initiation protocol.
+control*. This section explores the challenge of session control,
+using SIP (Session Initiation Protocol) as an example. SIP is typically
+paired with RTP to implement VOIP.
 
 |Stream|.4.1 Session Initiation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -21,45 +24,45 @@ designed with these different applications in mind and thus
 provides different capabilities than HTTP. The capabilities
 provided by SIP can be grouped into five categories:
 
--  User location—Determining the correct device with which to
+-  User location: Determining the correct device with which to
    communicate to reach a particular user
 
--  User availability—Determining if the user is willing or able to take
+-  User availability: Determining if the user is willing or able to take
    part in a particular communication session
 
--  User capabilities—Determining such items as the choice of media and
+-  User capabilities: Determining such items as the choice of media and
    coding scheme to use
 
--  Session setup—Establishing session parameters such as port numbers to
+-  Session setup: Establishing session parameters such as port numbers to
    be used by the communicating parties
 
--  Session management—A range of functions including transferring
+-  Session management: A range of functions including transferring
    sessions (e.g., to implement “call forwarding”) and modifying session
    parameters
 
-Most of these functions are easy enough to understand, but the issue
-of location bears some further discussion. Unlike HTTP, SIP is
-primarily used for human-to-human communication. Thus, it is important
-to be able to locate individual *users*, not just machines. And,
-unlike email, it’s not good enough just to locate a server that the
-user will be checking on at some later date and dump the message
-there—we need to know where the user is right now if we want to be
-able to communicate with him in real time. This is further complicated
-by the fact that a user might choose to communicate using a range of
-different devices, such as using his desktop PC when he’s in the
-office and using a handheld device when traveling. Multiple devices
-might be active at the same time and might have widely different
-capabilities (e.g., an alphanumeric pager and a PC-based video
-“phone”).  Ideally, it should be possible for other users to be able
-to locate and communicate with the appropriate device at any
-time. Furthermore, the user must be able to have control over when,
-where, and from whom he receives calls.
+Most of these functions are straightforward, but the issue of location
+bears further discussion. Since SIP is primarily used for
+human-to-human communication, it is important to be able to locate
+individual *users*, not just machines. And, unlike email, it’s not
+good enough just to locate a server that the user will be checking on
+at some later date and dump the message there—we need to know where
+the user is right now if we want to be able to communicate with them
+in real time. This is further complicated by the fact that a user
+might choose to communicate using a range of different devices, such
+as a desktop when in the office and a handheld device when
+traveling. Multiple devices might be active at the same time and might
+have widely different capabilities (e.g., an alphanumeric pager and a
+PC-based video “phone”).  Ideally, it should be possible for other
+users to be able to locate and communicate with the appropriate device
+at any time. Furthermore, the user must be able to have control over
+when, where, and from whom they receives calls.
 
-To enable a user to exercise the appropriate level of control over his
-calls, SIP introduces the notion of a proxy. A SIP proxy can be thought
-of as a point of contact for a user to which initial requests for
-communication with him are sent. Proxies also perform functions on
-behalf of callers. We can see how proxies work best through an example.
+To enable a user to exercise the appropriate level of control over
+their calls, SIP introduces the notion of a proxy. A SIP proxy can be
+thought of as a point of contact for a user to which initial requests
+for communication with a given person are sent. Proxies also perform
+functions on behalf of callers. We can see how proxies work best
+through an example.
 
 .. _fig-sipproxy:
 .. figure:: stream/figures/f09-08-9780123850591.png
@@ -72,9 +75,9 @@ Consider the two users in :numref:`Figure %s <fig-sipproxy>`. The
 first thing to notice is that each user has a name in the format
 ``user@domain``, very much like an email address. When user Bruce
 wants to initiate a session with Larry, he sends his initial SIP
-message to the local proxy for his domain, ``systemsapproach.org``. Among other
-things, this initial message contains a *SIP URI*—these are a form of
-uniform resource identifier which look like this:
+message to the local proxy for his domain, ``systemsapproach.org``.
+Among other things, this initial message contains a *SIP URI*—these
+are a form of uniform resource identifier which look like this:
 
 ::
 
@@ -167,18 +170,19 @@ acceptable to Larry and the device, considering the options that were
 proposed in Bruce’s ``invite``. In this way, mutually acceptable session
 parameters are agreed to before the media flow starts.
 
-The other big issue we have glossed over is that of locating the correct
-device for Larry. First, Bruce’s computer had to send its ``invite`` to
-the ``systemsapproach.org`` proxy. This could have been a configured piece of
-information in the computer, or it could have been learned by DHCP. Then
-the ``systemsapproach.org`` proxy had to find the ``princeton.edu`` proxy. This
-could be done using a special sort of DNS lookup that would return the
-IP address of the SIP proxy for the domain. (This is similar to how
-email servers can be found as discussed in Chapter |Naming|.) Finally, the ``princeton.edu`` proxy had to
-find a device on which Larry could be contacted. Typically, a proxy
-server has access to a location database that can be populated in
-several ways. Manual configuration is one option, but a more flexible
-option is to use the *registration* capabilities of SIP.
+The other big issue we have glossed over is that of locating the
+correct device for Larry. First, Bruce’s computer had to send its
+``invite`` to the ``systemsapproach.org`` proxy. This could have been
+a configured piece of information in the computer, or it could have
+been learned by DHCP. Then the ``systemsapproach.org`` proxy had to
+find the ``princeton.edu`` proxy. This could be done using a special
+sort of DNS lookup that would return the IP address of the SIP proxy
+for the domain. (This is similar to how email servers can be found as
+discussed in Chapter |Naming|.) Finally, the ``princeton.edu`` proxy
+had to find a device on which Larry could be contacted. Typically, a
+proxy server has access to a location database that can be populated
+in several ways. Manual configuration is one option, but a more
+flexible option is to use the *registration* capabilities of SIP.
 
 A user can register with a location service by sending a SIP
 ``register`` message to the “registrar” for his domain. This message
@@ -202,11 +206,3 @@ to do with telephony. For example, SIP supports operations
 that enable a call to be routed to a “music-on-hold” server or a
 voicemail server. It is widely used for video conferencing, and can
 also be used for instant messaging.
-
-
-
-
-
-
-
-.. Todo

--- a/stream/session.rst
+++ b/stream/session.rst
@@ -9,17 +9,19 @@ that we discussed in Chapter |Apps|. However, applications for
 human-to-human communication, such as VOIP or multi-party
 conferencing, don't conform so well to that model. There is no
 well-defined server for a client to connect to. Instead, we want to
-establish a communication *session* among the participants. These
-sorts of applications typically use something called *session
-control*. This section explores the challenge of session control,
-using SIP (Session Initiation Protocol) as an example. SIP is typically
-paired with RTP to implement VOIP.
+establish a communication *session* among the
+participants. Participants might also wish to be reached on different
+devices at different points in time. These sorts of applications
+typically use something called *session control*. This section
+explores the challenge of session control, using SIP (Session
+Initiation Protocol) as an example. SIP is typically paired with RTP
+to implement VOIP.
 
 |Stream|.4.1 Session Initiation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 SIP bears a certain resemblance to
-HTTP, being based on a similar request/response model. However, it is
+HTTP, and is based on a similar request/response model. However, it is
 designed with these different applications in mind and thus
 provides different capabilities than HTTP. The capabilities
 provided by SIP can be grouped into five categories:

--- a/stream/transport.rst
+++ b/stream/transport.rst
@@ -3,11 +3,11 @@
 |Stream|.3 Transport Protocol
 ------------------------------
 
-We now turn our attention to the transport protocol used deliver
-real-time media, which as we noted in Section |Stream|.2, needs to
+We now turn our attention to the transport protocol used to deliver
+real-time media, which as we noted in Section |Stream|.1, needs to
 avoid the possibility of unbounded delay by retransmitting dropped
-packets. The protocol also needs to account other application
-requirements, which sometimes include synchronizing separate audio
+packets. The protocol also needs to account for other application
+requirements, such as synchronizing separate audio
 and video streams.
 
 Settling on the functionality to be bundled in a *Real-time Transport

--- a/stream/transport.rst
+++ b/stream/transport.rst
@@ -1,42 +1,34 @@
-|Stream|.3 Transport Issues
----------------------------
+.. _artifact-rtp:
 
-In Chapter |Apps| we saw how streaming video could be delivered over
-HTTP, thus leveraging widely deployed protocols and much of the
-Internet's infrastructure including CDNs. However, there are still
-plenty of applications that need relatively timely delivery of their
-data, such as video conferencing, voice over IP, and real-time
-streaming (for live events, for example). HTTP and TCP are less well
-suited to applications with tight delivery constraints due to, among
-other things, the potential for unbounded delay when retransmitting
-dropped packets.
+|Stream|.3 Transport Protocol
+------------------------------
 
-Multi-media applications are a diverse group, so the
-protocols to support them must accommodate varying requirements. This
-includes potentially dealing with interactions among
-*different* applications, such as the synchronization of audio and video
-streams. We will see below how these concerns affected the design of
-the *Real-time
-Transport Protocol* (RTP).
+We now turn our attention to the transport protocol used deliver
+real-time media, which as we noted in Section |Stream|.2, needs to
+avoid the possibility of unbounded delay by retransmitting dropped
+packets. The protocol also needs to account other application
+requirements, which sometimes include synchronizing separate audio
+and video streams.
 
-Much of RTP actually derives from protocol functionality that was
-originally embedded in the application itself. Two of the first such
-applications were ``vic`` and ``vat``, the former supporting real-time
-video and the latter supporting real-time audio. Both applications
-originally ran directly over UDP, while the designers figured out
-which features were needed to handle the real-time nature of the
-communication. Later, they realized that these features could be
-useful to many other applications and defined a protocol with those
-features. That protocol was eventually standardized as RTP.
+Settling on the functionality to be bundled in a *Real-time Transport
+Protocol (RTP)*, as the result came to be called, happened
+iteratively. Early prototypes embedded the functionality in the
+application, the first two of the first were ``vic`` and ``vat``; the
+former supported real-time video and the latter supported real-time
+audio. Both applications originally ran directly over UDP, while the
+designers figured out which features were needed to handle the
+real-time nature of the communication. Later, they realized that these
+features could be useful to many other applications and defined a
+protocol with those features.
 
-RTP can run over many lower-layer protocols, but commonly runs
-over UDP. That leads to the protocol stack shown in :numref:`Figure %s
+RTP can run over many lower-layer protocols, but commonly runs over
+UDP. That leads to the protocol stack shown in :numref:`Figure %s
 <fig-vat-stack>`. Note that we are therefore running a transport
-protocol over a transport protocol (just as QUIC does). UDP provides a minimal
-level of functionality, and the basic demultiplexing based on port
-numbers is just what RTP needs as a starting point. So,
-rather than recreate port numbers in RTP, RTP outsources the
-demultiplexing function to UDP.
+protocol over a transport protocol (just as QUIC does). UDP provides a
+minimal level of functionality, and the basic demultiplexing based on
+port numbers is just what RTP needs as a starting point. So, rather
+than recreate port numbers in RTP, RTP outsources the demultiplexing
+function to UDP.
 
 .. _fig-vat-stack:
 .. figure:: stream/figures/f05-22-9780123850591.png
@@ -45,22 +37,24 @@ demultiplexing function to UDP.
 
    Protocol stack for multimedia applications using RTP.
 
-|Stream|.3.1 Requirements
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+|Stream|.3.1 Common Functionality
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The most basic requirement for a general-purpose multimedia protocol
-is that it allows similar applications to interoperate with each
-other. For example, it should be possible for two independently
-implemented audioconferencing applications to talk to each other. This
-immediately suggests that the applications should use the same method
-of encoding and compressing voice; otherwise, the data sent by one
-party will be incomprehensible to the receiving party. With a
-multitude of different coding schemes for voice, each with its own
-trade-offs among quality, bandwidth requirements, and computational
-cost, we can not decree that only one such scheme can be used.
-Instead, our protocol should provide a way that a sender can tell a
-receiver which coding scheme it wants to use, and possibly negotiate
-until a scheme that is available to both parties is identified.
+RTP's design was an exercise in identifying functionality that is
+common to all (or most) real-time applications. This suggests an
+obvious starting point: a general-purpose multimedia protocol must
+allow similar applications to interoperate with each other. For
+example, it should be possible for two independently implemented
+audioconferencing applications to talk to each other. This immediately
+suggests that the applications should use the same method of encoding
+and compressing voice; otherwise, the data sent by one party will be
+incomprehensible to the receiving party. With a multitude of different
+coding schemes for voice, each with its own trade-offs among quality,
+bandwidth requirements, and computational cost, we can not decree that
+only one such scheme can be used.  Instead, our protocol should
+provide a way that a sender can tell a receiver which coding scheme it
+wants to use, and possibly negotiate until a scheme that is available
+to both parties is identified.
 
 Just as with audio, there are many different video coding schemes. Thus,
 we see that the first common function that RTP can provide is the
@@ -69,30 +63,31 @@ serves to identify the type of application (e.g., audio or video); once
 we know what coding algorithm is being used, we know what type of data
 is being encoded as well.
 
-Another important requirement is to enable the recipient of a data
+A second important function is to enable the recipient of a data
 stream to determine the timing relationship among the received data.
 Real-time applications need to place received data into a *playback
-buffer* to smooth out the jitter that may have been introduced into the
-data stream during transmission across the network. Thus, some sort of
-timestamping of the data will be necessary to enable the receiver to
-play it back at the appropriate time.
+buffer* to smooth out the jitter that may have been introduced into
+the data stream during transmission across the network. Thus, some
+sort of timestamping of the data will be necessary to enable the
+receiver to play it back at the appropriate time.
 
 Related to the timing of a single media stream is the issue of
 synchronization of multiple media in a conference. The obvious example
 of this would be to synchronize an audio and video stream that are
-originating from the same sender. As we will see below, this is a
+originating from the same sender. As we describe below, this is a
 slightly more complex problem than playback time determination for a
 single stream.
 
-Another important function to be provided is an indication of packet
-loss. An application with tight latency bounds generally
-cannot use a reliable transport like TCP because retransmission of data
-to correct for loss would probably cause the packet to arrive too late
-to be useful. Thus, the application must be able to deal with missing
-packets, and the first step in dealing with them is noticing that they
-are in fact missing. As an example, a video application using MPEG
-encoding may take different actions when a packet is lost, depending on
-whether the packet came from an I frame, a B frame, or a P frame.
+A third general function to be provided is an indication of packet
+loss. As we've discussed, an application with tight latency bounds
+generally cannot use a reliable transport like TCP because
+retransmission of data to correct for loss would probably cause the
+packet to arrive too late to be useful. Thus, the application must be
+able to deal with missing packets, and the first step in dealing with
+them is noticing that they are in fact missing. As an example, a video
+application using MPEG encoding may take different actions when a
+packet is lost, depending on whether the packet came from an I frame,
+a B frame, or a P frame.
 
 Packet loss is also a potential indicator of congestion. Since real-time
 multimedia applications do not run over TCP, they also miss
@@ -103,39 +98,40 @@ consumed. Clearly, to make this work, the receiver needs to notify the
 sender that losses are occurring so that the sender can adjust its
 coding parameters.
 
-Another common function across multimedia applications is the concept
-of frame boundary indication. A frame in this context is application
+A fourth common function across multimedia applications is mechanism
+that indicates frame boundaries, where a frame is application
 specific. For example, it may be helpful to notify a video application
-that a certain set of packets correspond to a single frame. In an
-audio application it is helpful to mark the beginning of a
-“talkspurt,” which is a collection of sounds or words followed by
-silence. The receiver can then identify the silences between
+that a certain set of packets correspond to a single video frame,
+whereas in an audio application, it is helpful to mark the beginning
+of a “talkspurt” (a collection of sounds or words followed by
+silence). The receiver can then identify the silences between
 talkspurts and use them as opportunities to move the playback
 point. This follows the observation that slight shortening or
 lengthening of the spaces between words are not perceptible to users,
 whereas shortening or lengthening the words themselves is both
 perceptible and annoying.
 
-A final function that we might want to put into the protocol is some
-way of identifying senders that is more user-friendly than an IP
-address. Audio and video conferencing applications can display strings
-such as ``Username <user@example.com>`` on their control panels, and thus
-the application protocol should support the association of such a
-string with a data stream.
+A final function that we might want to put into a general real-time
+protocol is some way of identifying senders that is more user-friendly
+than an IP address. Audio and video conferencing applications can
+display strings such as ``Username <user@example.com>`` on their
+control panels, and thus the application protocol should support the
+association of such a string with a data stream.
 
-In addition to the functionality that is required from our protocol, we
-note an additional requirement: it should make reasonably efficient use
-of bandwidth. Put another way, we don’t want to introduce a lot of extra
-bits that need to be sent with every packet in the form of a long
-header. The reason for this is that audio packets, one of the
-most common types of multimedia data, tend to be small, so as to reduce
-the time it takes to fill them with samples. Long audio packets would
-mean high latency due to packetization, which has a negative effect on
-the perceived quality of conversations. Since the data packets themselves are
-short, a large header would consume a relatively large amount of link
-bandwidth, thus reducing the available capacity
-for “useful” data. We will see several aspects of the design of RTP that
-have been influenced by the necessity of keeping the header short.
+In addition to the common functionality that we've identified, there
+is also the requirement that the transport protocol should make
+reasonably efficient use of bandwidth. Put another way, we don’t want
+to introduce a lot of extra bits that need to be sent with every
+packet in the form of a long header. The reason for this is that audio
+packets, one of the most common types of multimedia data, tend to be
+small, so as to reduce the time it takes to fill them with
+samples. Long audio packets would mean high latency due to
+packetization, which has a negative effect on the perceived quality of
+conversations. Since the data packets themselves are short, a large
+header would consume a relatively large amount of link bandwidth, thus
+reducing the available capacity for “useful” data. We will see several
+aspects of the design of RTP that have been influenced by the
+necessity of keeping the header short.
 
 You could argue whether every single feature just described *really*
 needs to be in a real-time transport protocol, and you could probably
@@ -146,20 +142,27 @@ putting a timestamping mechanism into RTP, we save every developer of a
 real-time application from inventing their own. We also increase the
 chances that two different real-time applications might interoperate.
 
-|Stream|.3.2 RTP Design
-~~~~~~~~~~~~~~~~~~~~~~~~
+|Stream|.3.2 Protocol Definition
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Now that we have seen the rather long list of requirements for our
-transport protocol for multimedia, we turn to the details of the
-protocol that has been specified to meet those requirements. This
-protocol, RTP, was developed in the IETF and is in widespread use. The
-RTP standard actually defines a pair of protocols, RTP and the Real-time
-Transport Control Protocol (RTCP). The former is used for the exchange
-of multimedia data, while the latter is used to periodically send
-control information associated with a certain data flow. When running
-over UDP, the RTP data stream and the associated RTCP control stream use
-consecutive transport-layer ports. The RTP data uses an even port number
-and the RTCP control information uses the next higher (odd) port number.
+Now that we have seen the rather long list of functions that it makes
+sense for general real-time transport protocol to bundle, we turn to
+the details of the specific protocol, RTP.  The standard, as
+originally defined in RFC 1889 (and later updated by RFC 3550)
+actually defines a pair of protocols, RTP and the Real-time Transport
+Control Protocol (RTCP). The former is used for the exchange of
+multimedia data, while the latter is used to periodically send control
+information associated with a certain data flow. When running over
+UDP, the RTP data stream and the associated RTCP control stream use
+consecutive transport-layer ports. The RTP data uses an even port
+number and the RTCP control information uses the next higher (odd)
+port number.
+
+.. admonition:: Further Reading
+
+   H. Schulzrinne, S. Casner, R. Frederick, V. Jacobson.  `RTP: A
+   Transport Protocol for Real-Time Applications
+   <https://www.rfc-editor.org/info/rfc3550>`__. RFC 3550, July 2003.
 
 Because RTP is designed to support a wide variety of applications, it
 provides a flexible mechanism by which new applications can be developed
@@ -176,26 +179,30 @@ Alternatively, the format of the data might be much more complex; an
 MPEG-encoded video stream, for example, would need to have a good deal
 of structure to represent all the different types of information.
 
-.. _key-alf:
-.. admonition::  Key Takeaway
+This design embodies an architectural principle known as *Application
+Level Framing* (ALF). This principle was put forward by Clark and
+Tennenhouse in 1990 as a new way to design protocols for emerging
+multimedia applications. They recognized that these new applications
+were unlikely to be well served by existing protocols such as TCP, and
+that furthermore they might not be well served by any sort of
+“one-size-fits-all” protocol. At the heart of this principle is the
+belief that an application understands its own needs best. For
+example, an MPEG video application knows how best to recover from lost
+frames and how to react differently if an I frame or a B frame is
+lost. The same application also understands best how to segment the
+data for transmission—for example, it’s better to send the data from
+different frames in different datagrams, so that a lost packet only
+corrupts a single frame, not two. It is for this reason that RTP
+leaves so many of the protocol details to the profile and format
+documents that are specific to an application.
 
-   The design of RTP embodies an architectural principle known as
-   *Application Level Framing* (ALF). This principle was put forward
-   by Clark and Tennenhouse in 1990 as a new way to design protocols
-   for emerging multimedia applications. They recognized that these
-   new applications were unlikely to be well served by existing
-   protocols such as TCP, and that furthermore they might not be well
-   served by any sort of “one-size-fits-all” protocol. At the heart of
-   this principle is the belief that an application understands its
-   own needs best. For example, an MPEG video application knows how
-   best to recover from lost frames and how to react differently if an
-   I frame or a B frame is lost. The same application also understands
-   best how to segment the data for transmission—for example, it’s
-   better to send the data from different frames in different
-   datagrams, so that a lost packet only corrupts a single frame, not
-   two. It is for this reason that RTP leaves so many of the protocol
-   details to the profile and format documents that are specific to an
-   application.
+.. admonition:: Futher Reading
+
+   D. Clark and D. Tennenhouse. `Architectural Considerations for a
+   New Generation of Protocols
+   <https://dl.acm.org/doi/10.1145/99508.99553>`__.
+   ACM SIGCOMM '90 Symposium, August 1990.
+
 
 Header Format
 +++++++++++++++
@@ -271,13 +278,12 @@ to another based on information about resource availability in the
 network or feedback on application quality. The exact usage of the
 payload type is also determined by the application profile.
 
-Note that the payload type is generally not used as a demultiplexing key
-to direct data to different applications (or to different streams within
-a single application, such as the audio and video stream for a
+Note that the payload type is generally not used as a demultiplexing
+key to direct data to different applications (or to different streams
+within a single application, such as the audio and video stream for a
 videoconference). This is because such demultiplexing is typically
-provided at a lower layer (e.g., by UDP, as described in a previous
-section). Thus, two media streams using RTP would typically use
-different UDP port numbers.
+provided at a lower layer by UDP. In other words, two media streams
+using RTP would typically use different UDP port numbers.
 
 The sequence number is used to enable the receiver of an RTP stream to
 detect missing and misordered packets. The sender simply increments the
@@ -417,31 +423,32 @@ bandwidth. In an audioconference, for example, no more than two or three
 senders are likely to send audio data at any instant, since there is no
 point in everyone talking at once. But there is no such social limit on
 everyone sending control traffic, and this could be a severe problem in
-a conference with thousands of participants. To deal with this problem,
-RTCP has a set of mechanisms by which the participants scale back their
-reporting frequency as the number of participants increases. These rules
-are somewhat complex, but the basic goal is this: Limit the total amount
-of RTCP traffic to a small percentage (typically 5%) of the RTP data
-traffic. To accomplish this goal, the participants should know how much
-data bandwidth is likely to be in use (e.g., the amount to send three
-audio streams) and the number of participants. They learn the former
-from means outside RTP (known as *session management*, discussed in
-the next section), and they learn the latter from the RTCP reports of
-other participants. Because RTCP reports might be sent at a very low
-rate, it might only be possible to get an approximate count of the
-current number of recipients, but that is typically sufficient. Also, it
-is recommended to allocate more RTCP bandwidth to active senders, on the
-assumption that most participants would like to see reports from
-them—for example, to find out who is speaking.
+a conference with thousands of participants.
 
-Once a participant has determined how much bandwidth it can consume with
-RTCP traffic, it sets about sending periodic reports at the appropriate
-rate. Sender reports and receiver reports differ only in that the former
-include some extra information about the sender. Both types of reports
-contain information about the data that was received from all sources in
-the most recent reporting period.
+To deal with this problem, RTCP has a set of mechanisms by which the
+participants scale back their reporting frequency as the number of
+participants increases.  These rules are complex, but the goal is to
+limit the total amount of RTCP traffic to a small percentage
+(typically 5%) of the RTP data traffic. To accomplish this, the
+participants should know how much data bandwidth is likely to be in
+use (e.g., the amount to send three audio streams) and the number of
+participants. They learn the former from means outside RTP (known as
+*session management*, discussed in the next section), and they learn
+the latter from the RTCP reports of other participants. Because RTCP
+reports might be sent at a very low rate, it might only be possible to
+get an approximate count of the current number of recipients, but that
+is typically sufficient. Also, it is recommended to allocate more RTCP
+bandwidth to active senders, on the assumption that most participants
+would like to see reports from them—for example, to find out who is
+speaking.
 
-The extra information in a sender report consists of
+Once a participant has determined how much bandwidth it can consume
+with RTCP traffic, it sets about sending periodic reports at the
+appropriate rate. Sender reports and receiver reports differ only in
+that the former include some extra information about the sender. Both
+types of reports contain information about the data that was received
+from all sources in the most recent reporting period.  The extra
+information in a sender report consists of the following:
 
 -  A timestamp containing the actual time of day when this report was
    generated
@@ -485,30 +492,30 @@ following statistics for the source in question:
 As you might imagine, the recipients of this information can learn a
 lot about the state of the session. In particular, they can see if
 other recipients are getting much better quality from some sender than
-they are, which might be an indication of a problem in the network that needs
-to be attended to. In addition, if a sender notices that many
-receivers are experiencing high loss of its packets, it might decide
-that it should reduce its sending rate or use a coding scheme that is
-more resilient to loss.
+they are, which might be an indication of a problem in the network
+that needs to be attended to. In addition, if a sender notices that
+many receivers are experiencing high loss of its packets, it might
+decide that it should reduce its sending rate or use a coding scheme
+that is more resilient to loss.
 
-The final aspect of RTCP that we will consider is the source
-description packet. Such a packet contains, at a minimum, the SSRC of
-the sender and the sender’s CNAME. The canonical name is derived in
-such a way that all applications that generate media streams that
-might need to be synchronized (e.g., separately generated audio and
-video streams from the same user) will choose the same CNAME even
-though they might choose different SSRC values. This enables a
-receiver to identify the media stream that came from the same
-sender. The most common format of the CNAME is ``user@host``, where
-``host`` is the fully qualified domain name of the sending machine.
-Thus, an application launched by the user whose user name is ``jdoe``
-running on the machine ``cicada.cs.princeton.edu`` would use the
-string ``jdoe@cicada.cs.princeton.edu`` as its CNAME. The large and
-variable number of bytes used in this representation would make it a
-bad choice for the format of an SSRC, since the SSRC is sent with
-every data packet and must be processed in real time. Allowing CNAMEs
-to be bound to SSRC values in periodic RTCP messages enables a compact
-and efficient format for the SSRC.
+A final aspect of RTCP to consider is the source description packet.
+Such a packet contains, at a minimum, the SSRC of the sender and the
+sender’s CNAME. The canonical name is derived in such a way that all
+applications that generate media streams that might need to be
+synchronized (e.g., separately generated audio and video streams from
+the same user) will choose the same CNAME even though they might
+choose different SSRC values. This enables a receiver to identify the
+media stream that came from the same sender. The most common format of
+the CNAME is ``user@host``, where ``host`` is the fully qualified
+domain name of the sending machine.  Thus, an application launched by
+the user whose user name is ``jdoe`` running on the machine
+``cicada.cs.princeton.edu`` would use the string
+``jdoe@cicada.cs.princeton.edu`` as its CNAME. The large and variable
+number of bytes used in this representation would make it a bad choice
+for the format of an SSRC, since the SSRC is sent with every data
+packet and must be processed in real time. Allowing CNAMEs to be bound
+to SSRC values in periodic RTCP messages enables a compact and
+efficient format for the SSRC.
 
 Other items may be included in the source description packet, such as
 the real name and email address of the user. These are used in user
@@ -524,4 +531,5 @@ applications without making the protocol itself impossible to implement.
 RTP has proven very successful in this regard, forming the basis for
 many real-time multimedia applications run over the Internet today.
 
-.. todo sidebar on SRTP
+.. TODO -- A sidebar on SRTP
+


### PR DESCRIPTION
Beyond a typical light edit...
-   Trimmed Intro, focusing on app requirements
-   Cut lossless compression
-   Split "Image Representation" out from rest of Image Compression
-   Reframed "Requirements" as "Common Functions" in RTP Design section